### PR TITLE
Grid Layout Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
-## 0.1.2
+## 0.1.4
+
+- Added `onKeyboardLayoutChange` prop — fires when the keyboard switches between linear and grid layouts, providing `height` and `isGrid` via `event.nativeEvent`.
+- Added `gridSeparatorColor` prop to customize the separator color in grid layout.
+- Added `linearSeparatorColor` prop to customize the separator color in linear layout.
+- Keyboard height is now dynamic — use `onKeyboardLayoutChange` to update the component's height instead of a static value.
+
+## 0.1.3
 
 - Disable RN select gesture intercept during UISearchBar editing
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,13 @@ No additional setup is required.
 Import and use the `TvosKeyboardView` component.
 
 ```tsx md title="App.tsx"
+import { useState } from 'react';
 import { TvosKeyboardView } from '@logicwind/react-native-tvos-keyboard';
 
+const [keyboardHeight, setKeyboardHeight] = useState(200);
+
 <TvosKeyboardView
-  style={styles.keyboard}
+  style={[styles.keyboard, { height: keyboardHeight }]}
   onTextChange={(e) => console.log('Text: ', e.nativeEvent.text)}
   onFocus={(e) => {
     if (e.nativeEvent.focused !== undefined && e.nativeEvent.focused) {
@@ -56,11 +59,14 @@ import { TvosKeyboardView } from '@logicwind/react-native-tvos-keyboard';
       console.log('Focused: false');
     }
   }}
+  onKeyboardLayoutChange={(e) => {
+    setKeyboardHeight(e.nativeEvent.height);
+    console.log('isGrid: ', e.nativeEvent.isGrid);
+  }}
 />;
 
 const styles = StyleSheet.create({
   keyboard: {
-    height: 200,
     width: '100%',
     backgroundColor: 'transparent',
   },
@@ -71,23 +77,16 @@ const styles = StyleSheet.create({
 
 The `TvosKeyboardView` component displays the native Apple TV keyboard and supports the following props:
 
-| Prop           | Type              | Description                                                                                     |
-| -------------- | ----------------- | ----------------------------------------------------------------------------------------------- |
-| `onTextChange` | `(event) => void` | Callback triggered when the text input changes. Access the text via `event.nativeEvent.text`.   |
-| `onFocus`      | `(event) => void` | Called when the keyboard gains focus. Use `event.nativeEvent.focused` to check if it’s focused. |
-| `onBlur`       | `(event) => void` | Called when the keyboard loses focus. Use `event.nativeEvent.blurred` to check if it’s blurred. |
+| Prop                      | Type              | Description                                                                                                                          |
+| ------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `onTextChange`            | `(event) => void` | Callback triggered when the text input changes. Access the text via `event.nativeEvent.text`.                                        |
+| `onFocus`                 | `(event) => void` | Called when the keyboard gains focus. Use `event.nativeEvent.focused` to check if it’s focused.                                      |
+| `onBlur`                  | `(event) => void` | Called when the keyboard loses focus. Use `event.nativeEvent.blurred` to check if it’s blurred.                                      |
+| `onKeyboardLayoutChange`  | `(event) => void` | Called when the keyboard switches between linear and grid layouts. Provides `event.nativeEvent.height` (number) and `event.nativeEvent.isGrid` (boolean). Use this to dynamically set the component height. |
+| `gridSeparatorColor`      | `ColorValue`      | Color of the separator line shown in grid keyboard layout.                                                                           |
+| `linearSeparatorColor`    | `ColorValue`      | Color of the separator line shown in linear keyboard layout.                                                                         |
 
-> 💡 **Note:** The keyboard has a fixed size and layout. Please use the style shown in the example to ensure proper rendering and alignment.
-
-```tsx md title="App.tsx"
-const styles = StyleSheet.create({
-  keyboard: {
-    height: 200,
-    width: '100%',
-    backgroundColor: 'transparent',
-  },
-});
-```
+> 💡 **Note:** The keyboard height changes dynamically depending on whether the grid or linear layout is active. Use `onKeyboardLayoutChange` to receive the correct height and apply it to the component’s style.
 
 ## react-native-tvos-keyboard is crafted mindfully at [Logicwind](https://www.logicwind.com?utm_source=github&utm_medium=github.com-logicwind&utm_campaign=react-native-tvos-keyboard)
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -5,11 +5,14 @@ import { TvosKeyboardView } from '@logicwind/react-native-tvos-keyboard';
 export default function App() {
   const [text, setText] = useState('');
   const [focused, setFocused] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(200);
+  const [isGrid, setIsGrid] = useState(false);
 
   return (
     <View style={styles.container}>
       <Text style={styles.text}>Text: {text}</Text>
       <Text style={styles.text}>isFocused: {focused ? 'true' : 'false'}</Text>
+      <Text style={styles.text}>isGrid: {isGrid ? 'true' : 'false'}</Text>
       {/* Top Button */}
       <TouchableOpacity
         style={styles.button}
@@ -23,7 +26,7 @@ export default function App() {
 
       {/* TV Keyboard */}
       <TvosKeyboardView
-        style={styles.keyboard}
+        style={[styles.keyboard, { height: keyboardHeight }]}
         onTextChange={(e) => setText(e.nativeEvent.text)}
         onFocus={(e) => {
           if (e.nativeEvent.focused !== undefined && e.nativeEvent.focused) {
@@ -34,6 +37,10 @@ export default function App() {
           if (e.nativeEvent.blurred !== undefined && e.nativeEvent.blurred) {
             setFocused(false);
           }
+        }}
+        onKeyboardLayoutChange={(e) => {
+          setKeyboardHeight(e.nativeEvent.height);
+          setIsGrid(e.nativeEvent.isGrid);
         }}
       />
 
@@ -53,7 +60,7 @@ export default function App() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
+
     justifyContent: 'center',
     backgroundColor: '#111',
   },
@@ -63,7 +70,6 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   keyboard: {
-    height: 200,
     width: '100%',
     backgroundColor: 'transparent',
   },
@@ -73,6 +79,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 50,
     borderRadius: 12,
     backgroundColor: '#1e90ff',
+    width: '30%',
+    marginHorizontal: 10,
   },
   buttonText: {
     fontSize: 22,

--- a/ios/TvosKeyboardViewManager.m
+++ b/ios/TvosKeyboardViewManager.m
@@ -7,5 +7,8 @@ RCT_EXPORT_VIEW_PROPERTY(onTextChange, RCTBubblingEventBlock)
 RCT_EXTERN_METHOD(focusSearchBar:(nonnull NSNumber *)reactTag)
 RCT_EXPORT_VIEW_PROPERTY(onFocus, RCTBubblingEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onBlur, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onKeyboardLayoutChange, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(gridSeparatorColor, UIColor)
+RCT_EXPORT_VIEW_PROPERTY(linearSeparatorColor, UIColor)
 
 @end

--- a/ios/TvosKeyboardViewManager.swift
+++ b/ios/TvosKeyboardViewManager.swift
@@ -29,6 +29,13 @@ class TvosKeyboardView: UIView, UISearchResultsUpdating, UISearchBarDelegate {
   @objc var onTextChange: RCTBubblingEventBlock?
   @objc var onFocus: RCTBubblingEventBlock?
   @objc var onBlur: RCTBubblingEventBlock?
+  @objc var onKeyboardLayoutChange: RCTBubblingEventBlock?
+  @objc var gridSeparatorColor: UIColor? { didSet { applySeparatorColor() } }
+  @objc var linearSeparatorColor: UIColor? { didSet { applySeparatorColor() } }
+
+  private var lastEmittedHeight: CGFloat = 0
+  private var currentIsGrid = false
+  private weak var observedKeyboardView: UIView?
 
   override init(frame: CGRect) {
     super.init(frame: frame)
@@ -38,6 +45,10 @@ class TvosKeyboardView: UIView, UISearchResultsUpdating, UISearchBarDelegate {
   required init?(coder: NSCoder) {
     super.init(coder: coder)
     setupSearchController()
+  }
+
+  deinit {
+    observedKeyboardView?.removeObserver(self, forKeyPath: "frame")
   }
 
   private func setupSearchController() {
@@ -71,6 +82,102 @@ class TvosKeyboardView: UIView, UISearchResultsUpdating, UISearchBarDelegate {
       containerVC.view.leadingAnchor.constraint(equalTo: self.leadingAnchor),
       containerVC.view.trailingAnchor.constraint(equalTo: self.trailingAnchor),
     ])
+  }
+
+  private func applySeparatorColor() {
+    let color = currentIsGrid ? gridSeparatorColor : linearSeparatorColor
+    guard let color = color else { return }
+    findAndColorSeparator(in: searchController.view, color: color)
+  }
+
+  private func updateSeparatorColor(_ color: UIColor) {
+    findAndColorSeparator(in: searchController.view, color: color)
+  }
+
+  private func findAndColorSeparator(in view: UIView, color: UIColor) {
+    if view.frame.height <= 1.0 && view.frame.width > 100 {
+      view.backgroundColor = color
+      return
+    }
+    for sub in view.subviews {
+      findAndColorSeparator(in: sub, color: color)
+    }
+  }
+
+  // Recursively finds the first view matching the given private class name
+  private func findView(named className: String, in view: UIView) -> UIView? {
+    if NSStringFromClass(type(of: view)) == className { return view }
+    for sub in view.subviews {
+      if let found = findView(named: className, in: sub) { return found }
+    }
+    return nil
+  }
+
+  private func emitKeyboardHeight() {
+    guard let kbView = findView(named: "_UIKBCompatInputView", in: searchController.view) else { return }
+
+    // KVO: watch this specific instance for frame changes (linear <-> grid switch)
+    if observedKeyboardView !== kbView {
+      observedKeyboardView?.removeObserver(self, forKeyPath: "frame")
+      kbView.addObserver(self, forKeyPath: "frame", options: [.new], context: nil)
+      observedKeyboardView = kbView
+    }
+
+    let h = kbView.frame.height
+    guard h > 0, h != lastEmittedHeight else { return }
+    lastEmittedHeight = h
+    currentIsGrid = h > 700
+    onKeyboardLayoutChange?(["height": h, "isGrid": currentIsGrid])
+    applySeparatorColor()
+  }
+
+  override func observeValue(forKeyPath keyPath: String?,
+                             of object: Any?,
+                             change: [NSKeyValueChangeKey: Any]?,
+                             context: UnsafeMutableRawPointer?) {
+    guard keyPath == "frame",
+          let view = object as? UIView,
+          view === observedKeyboardView else { return }
+    let h = view.frame.height
+    guard h > 0, h != lastEmittedHeight else { return }
+    lastEmittedHeight = h
+    onKeyboardLayoutChange?(["height": h, "isGrid": h > 700])
+  }
+
+  override func layoutSubviews() {
+    super.layoutSubviews()
+    // Defer to next run loop — by then RN has finished setting all props incl. onHeightChange
+    DispatchQueue.main.async { [weak self] in
+      self?.emitKeyboardHeight()
+    }
+  }
+
+  override func didMoveToWindow() {
+    super.didMoveToWindow()
+
+    if window == nil {
+      // View is being removed — tear down VC containment cleanly
+      if containerVC.parent != nil {
+        containerVC.beginAppearanceTransition(false, animated: false)
+        containerVC.endAppearanceTransition()
+        containerVC.willMove(toParent: nil)
+        containerVC.removeFromParent()
+      }
+      return
+    }
+
+    guard let parentVC = reactViewController() else { return }
+    if containerVC.parent == nil {
+      parentVC.addChild(containerVC)
+      // Fire viewWillAppear/viewDidAppear so UISearchContainerViewController
+      // registers its focus environment with the tvOS focus engine
+      containerVC.beginAppearanceTransition(true, animated: false)
+      containerVC.endAppearanceTransition()
+      containerVC.didMove(toParent: parentVC)
+      // Auto-focus the search bar so tvOS routes remote input here immediately,
+      // instead of leaving focus on the tab bar item that triggered navigation
+      focusSearchBar()
+    }
   }
 
   func focusSearchBar() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@logicwind/react-native-tvos-keyboard",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Native Apple TV keyboard for React Native tvOS with voice typing support.",
   "source": "./src/index.tsx",
   "main": "./lib/commonjs/index.js",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import {
   requireNativeComponent,
   UIManager,
   Platform,
-  type ViewStyle,
+  type ColorValue,
   type NativeSyntheticEvent,
   type ViewProps,
 } from 'react-native';
@@ -26,11 +26,18 @@ type OnTextChangeEvent = NativeSyntheticEvent<{
   text: string;
 }>;
 
+type OnKeyboardLayoutChangeEvent = NativeSyntheticEvent<{
+  height: number;
+  isGrid: boolean;
+}>;
+
 type TvosKeyboardProps = ViewProps & {
   onTextChange?: (event: OnTextChangeEvent) => void;
   onFocus?: (event: OnFocusEvent) => void;
   onBlur?: (event: OnBlurEvent) => void;
-  style?: ViewStyle;
+  onKeyboardLayoutChange?: (event: OnKeyboardLayoutChangeEvent) => void;
+  gridSeparatorColor?: ColorValue;
+  linearSeparatorColor?: ColorValue;
 };
 
 const ComponentName = 'TvosKeyboardView';


### PR DESCRIPTION
- Added `onKeyboardLayoutChange` prop — fires when the keyboard switches between linear and grid layouts, providing `height` and `isGrid` via `event.nativeEvent`.
- Added `gridSeparatorColor` prop to customize the separator color in grid layout.
- Added `linearSeparatorColor` prop to customize the separator color in linear layout.
- Keyboard height is now dynamic — use `onKeyboardLayoutChange` to update the component's height instead of a static value.
